### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ This will startup a self contained tc Runtime instance with a "Hello, World" web
 Additional Documentation
 ========================
 
-Full tc Server Documentation can me found at http://tcserver.docs.pivotal.io/
+Full tc Server Documentation can me found at https://tcserver.docs.pivotal.io/
 
-More on embedded tc Server can be found at http://tcserver.docs.pivotal.io/docs-tcserver/topics/postinstall-getting-started.html#postinstall-embedding-tc-server
+More on embedded tc Server can be found at https://tcserver.docs.pivotal.io/docs-tcserver/topics/postinstall-getting-started.html#postinstall-embedding-tc-server


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://tcserver.docs.pivotal.io/docs-tcserver/topics/postinstall-getting-started.html (404) with 1 occurrences migrated to:  
  https://tcserver.docs.pivotal.io/docs-tcserver/topics/postinstall-getting-started.html ([https](https://tcserver.docs.pivotal.io/docs-tcserver/topics/postinstall-getting-started.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tcserver.docs.pivotal.io/ with 1 occurrences migrated to:  
  https://tcserver.docs.pivotal.io/ ([https](https://tcserver.docs.pivotal.io/) result 301).